### PR TITLE
fix: add privacy control for private files

### DIFF
--- a/internal/i18n/locale/en.json
+++ b/internal/i18n/locale/en.json
@@ -22,7 +22,8 @@
 	"file": {
 		"overSizeError": " The file is over size",
 		"wrongTypeError": "The file type is illegal",
-		"parseFormFailed": "Failed to parse multiform data"
+		"parseFormFailed": "Failed to parse multiform data",
+		"permissionDenied": "Permission denied to access this file"
 	},
 	"init": {
 		"alreadyInit": "The database had been initialized.",

--- a/internal/i18n/locale/zh.json
+++ b/internal/i18n/locale/zh.json
@@ -21,7 +21,8 @@
 	"file": {
 		"overSizeError": "文件大小超过限定值",
 		"wrongTypeError": "错误的文件类型",
-		"parseFormFailed": "无法处理提交数据"
+		"parseFormFailed": "无法处理提交数据",
+		"permissionDenied": "无权访问此文件"
 	},
 	"init": {
 		"initializeIsRunning": "正在初始化...",

--- a/internal/logic/file/download_file_logic.go
+++ b/internal/logic/file/download_file_logic.go
@@ -5,6 +5,7 @@ import (
 	"path"
 
 	"github.com/suyuan32/simple-admin-common/enum/errorcode"
+	"github.com/suyuan32/simple-admin-common/i18n"
 	"github.com/suyuan32/simple-admin-common/utils/uuidx"
 	"github.com/zeromicro/go-zero/core/errorx"
 
@@ -51,7 +52,8 @@ func (l *DownloadFileLogic) DownloadFile(req *types.UUIDPathReq) (filePath strin
 			logx.Errorw("unauthorized download attempt", logx.Field("fileName", file.Name),
 				logx.Field("fileOwner", file.UserID),
 				logx.Field("requestUser", currentUserId))
-			return "", errorx.NewCodeError(errorcode.PermissionDenied, "file.permissionDenied")
+			return "", errorx.NewCodeError(errorcode.PermissionDenied,
+				l.svcCtx.Trans.Trans(l.ctx, "file.permissionDenied"))
 		}
 
 		logx.Infow("private download", logx.Field("fileName", file.Name),

--- a/internal/logic/file/download_file_logic.go
+++ b/internal/logic/file/download_file_logic.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"path"
 
+	"github.com/suyuan32/simple-admin-common/enum/errorcode"
 	"github.com/suyuan32/simple-admin-common/utils/uuidx"
+	"github.com/zeromicro/go-zero/core/errorx"
 
 	"github.com/suyuan32/simple-admin-file/internal/utils/dberrorhandler"
 
@@ -35,14 +37,25 @@ func (l *DownloadFileLogic) DownloadFile(req *types.UUIDPathReq) (filePath strin
 		return "", dberrorhandler.DefaultEntError(l.Logger, err, req)
 	}
 
+	currentUserId := l.ctx.Value("userId").(string)
+
 	if file.Status == 1 {
+		// Public file: anyone can download
 		logx.Infow("public download", logx.Field("fileName", file.Name),
-			logx.Field("userId", l.ctx.Value("userId").(string)),
+			logx.Field("userId", currentUserId),
 			logx.Field("filePath", file.Path))
 		return path.Join(l.svcCtx.Config.UploadConf.PublicStorePath, file.Path), nil
 	} else {
+		// Private file: only owner can download
+		if file.UserID != currentUserId {
+			logx.Errorw("unauthorized download attempt", logx.Field("fileName", file.Name),
+				logx.Field("fileOwner", file.UserID),
+				logx.Field("requestUser", currentUserId))
+			return "", errorx.NewCodeError(errorcode.PermissionDenied, "file.permissionDenied")
+		}
+
 		logx.Infow("private download", logx.Field("fileName", file.Name),
-			logx.Field("userId", l.ctx.Value("userId").(string)),
+			logx.Field("userId", currentUserId),
 			logx.Field("filePath", file.Path))
 		return path.Join(l.svcCtx.Config.UploadConf.PrivateStorePath, file.Path), nil
 	}


### PR DESCRIPTION
- Add privacy filter in file list to show only public files or user's own private files
- Return empty publicPath for private files to prevent broken images
- Add download permission check: private files can only be downloaded by owner
- Prevent unauthorized access to other users' private files